### PR TITLE
Define stancer_group and its label used in config.xml

### DIFF
--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -3,6 +3,11 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd"
 >
+  <groups>
+    <group id="stancer_group">
+      <label>Stancer</label>
+    </group>
+  </groups>
   <methods>
     <method name="stancer_payments">
       <allow_multiple_address>


### PR DESCRIPTION
In etc/config.xml this group is defined on the paument method: 
`<group>stancer_group</group>`

It needs to be defined in etc/payments.xml with a label in order to avoid an error on the backend order page:
Exception #0 (Exception): Warning: Undefined array key "label" in /var/www/html/vendor/magento/module-backend/Block/Widget/Grid/Column/Filter/Select.php on line 75